### PR TITLE
Implement GPT-4o synthesis service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+openai
+redis
+fakeredis

--- a/synthesis/main.py
+++ b/synthesis/main.py
@@ -1,0 +1,47 @@
+import os
+from fastapi import FastAPI, HTTPException
+import redis.asyncio as redis
+from openai import AsyncOpenAI
+
+app = FastAPI(title="Synthesis Service")
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+
+
+def build_prompt(events: list[str]) -> str:
+    joined = "\n".join(events)
+    return (
+        "Summarize the following events into a concise markdown report. "
+        "Highlight any novel ideas with a bullet starting with the 🧬 emoji. "
+        "Finish with a '### References' section listing any sources or notes.\n" 
+        f"Events:\n{joined}"
+    )
+
+
+async def generate_report(events: list[str]) -> str:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+    client = AsyncOpenAI(api_key=api_key)
+    prompt = build_prompt(events)
+    response = await client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+@app.post("/synthesize/{run_id}")
+async def synthesize(run_id: str):
+    key = f"run:{run_id}:events"
+    events = await redis_client.lrange(key, 0, -1)
+    if not events:
+        raise HTTPException(status_code=404, detail="No events found")
+    markdown = await generate_report(events)
+    return {"markdown": markdown}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -1,0 +1,38 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+
+# Ensure the package can be imported when the repository root contains dots.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import synthesis.main as main
+
+
+class DummyResponse:
+    def __init__(self, content):
+        self.choices = [type("Choice", (), {"message": type("Msg", (), {"content": content})()})]
+
+
+async def dummy_generate_report(events):
+    return "dummy markdown"
+
+
+async def setup_redis():
+    fake = fakeredis.aioredis.FakeRedis()
+    await fake.rpush("run:test:events", "e1", "e2")
+    return fake
+
+
+def test_synthesize(monkeypatch):
+    redis_instance = asyncio.run(setup_redis())
+    monkeypatch.setattr(main, "redis_client", redis_instance)
+    monkeypatch.setattr(main, "generate_report", dummy_generate_report)
+    client = TestClient(main.app)
+    resp = client.post("/synthesize/test")
+    assert resp.status_code == 200
+    assert resp.json()["markdown"] == "dummy markdown"


### PR DESCRIPTION
## Summary
- add new FastAPI service at `synthesis/main.py`
- aggregate events from redis and summarize via GPT-4o
- basic unit test covering endpoint
- include Python package requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7f33464483299dda515127c85854