### PR TITLE
Add novelty service and ingestion CLI

### DIFF
--- a/novelty/__init__.py
+++ b/novelty/__init__.py
@@ -1,0 +1,3 @@
+from .novelty import assess
+
+__all__ = ["assess"]

--- a/novelty/__main__.py
+++ b/novelty/__main__.py
@@ -1,0 +1,4 @@
+from .ingest import main
+
+if __name__ == "__main__":
+    main()

--- a/novelty/ingest.py
+++ b/novelty/ingest.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import chromadb
+from .novelty import _embed
+
+CHROMA_PATH = os.getenv("CHROMA_PATH", "chroma")
+client = chromadb.PersistentClient(path=CHROMA_PATH)
+collection = client.get_or_create_collection("papers")
+
+
+def stream_pubmed(limit: int = 1_000_000, batch: int = 1000):
+    query = "all[sb]"
+    for start in range(0, limit, batch):
+        cmd = (
+            f"esearch -db pubmed -query '{query}' -retstart {start} -retmax {batch} "
+            "| efetch -format abstract"
+        )
+        with subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, text=True) as proc:
+            abstract = []
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    if abstract:
+                        yield " ".join(abstract)
+                        abstract = []
+                else:
+                    abstract.append(line)
+            if abstract:
+                yield " ".join(abstract)
+        if start + batch >= limit:
+            break
+
+
+def main():
+    for idx, abstract in enumerate(stream_pubmed(), start=1):
+        emb = _embed(abstract)
+        collection.add(embeddings=[emb], ids=[f"pmid-{idx}"], documents=[abstract])
+        if idx % 100 == 0:
+            print(f"Ingested {idx}", flush=True)
+        if idx >= 1_000_000:
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/novelty/novelty.py
+++ b/novelty/novelty.py
@@ -1,0 +1,58 @@
+import os
+import requests
+import chromadb
+from chromadb.utils import embedding_functions
+
+OPENROUTER_API_KEY = os.getenv('OPENROUTER_API_KEY')
+CHROMA_PATH = os.getenv('CHROMA_PATH', 'chroma')
+
+client = chromadb.PersistentClient(path=CHROMA_PATH)
+collection = client.get_or_create_collection('papers')
+
+# OpenRouter embedding using text-embedding-ada
+
+def _embed(text: str) -> list[float]:
+    if not OPENROUTER_API_KEY:
+        raise EnvironmentError('OPENROUTER_API_KEY not set')
+    url = 'https://openrouter.ai/api/v1/embeddings'
+    payload = {
+        'model': 'text-embedding-ada-002',
+        'input': text,
+    }
+    headers = {
+        'Authorization': f'Bearer {OPENROUTER_API_KEY}',
+    }
+    resp = requests.post(url, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data['data'][0]['embedding']
+
+
+def _crossref_hits(text: str) -> int:
+    url = 'https://api.crossref.org/works'
+    params = {
+        'query.bibliographic': text,
+        'rows': 1,
+    }
+    resp = requests.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get('message', {}).get('total-results', 0)
+
+
+def assess(text: str) -> dict:
+    """Assess novelty of given text."""
+    embed = _embed(text)
+    res = collection.query(query_embeddings=[embed], n_results=5)
+    distances = res.get('distances', [[1]])[0]
+    avg_dist = sum(distances) / len(distances) if distances else 1.0
+    crossref = _crossref_hits(text)
+    novel = avg_dist > 0.38 and crossref == 0
+    score = avg_dist
+    evidence = [f'avg_cosine_dist={avg_dist:.3f}', f'crossref_hits={crossref}']
+    if novel:
+        evidence.append('Novel by threshold')
+    return {
+        'score': float(score),
+        'evidence': evidence,
+    }


### PR DESCRIPTION
## Summary
- implement novelty assessment with OpenRouter embeddings
- compare new texts to a Chroma vector DB
- ingest 1M PubMed abstracts via EDirect
- expose a module entrypoint

## Testing
- `python -m novelty.ingest --help` *(fails: `esearch` and `efetch` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7f212fc88329bad1540f04ae6ec1